### PR TITLE
fix: issue with override values not being used

### DIFF
--- a/sso/zarf.yaml
+++ b/sso/zarf.yaml
@@ -62,7 +62,7 @@ components:
       # renovate: datasource=helm
       - name: flux-app
         url: https://defenseunicorns.github.io/uds-support-charts/
-        version: 1.0.7
+        version: 1.0.5
         releaseName: authservice-flux
         namespace: bigbang
         valuesFiles:


### PR DESCRIPTION
Reverting to older uds-support-chart which expects values override to be in a different format.